### PR TITLE
Add basic patch versioning logic 

### DIFF
--- a/models/init.go
+++ b/models/init.go
@@ -1,0 +1,6 @@
+package models
+
+type Init struct {
+	Content *string `json:"content"`
+	Version int     `json:"version"`
+}

--- a/models/update.go
+++ b/models/update.go
@@ -1,0 +1,14 @@
+package models
+
+type Update struct {
+	Type        UpdateType `json:"type"`
+	Version     int        `json:"version"`
+	Patch       string     `json:"patch"`
+	CursorDelta int        `json:"cursor_delta"`
+}
+
+type UpdateType int
+
+const (
+	Edit UpdateType = 0
+)

--- a/websockets/client.go
+++ b/websockets/client.go
@@ -52,6 +52,10 @@ func (c *Client) read() {
 // write sends messages to the WebSocket connection whenever new messages are
 // sent into the Client's channel.
 func (c *Client) write() {
+	defer func() {
+		c.conn.WriteMessage(gorillaws.CloseMessage, []byte{})
+	}()
+
 	for message := range c.send {
 		err := c.conn.WriteMessage(gorillaws.TextMessage, message)
 		if err != nil {
@@ -59,5 +63,4 @@ func (c *Client) write() {
 			return
 		}
 	}
-	c.conn.WriteMessage(gorillaws.CloseMessage, []byte{})
 }

--- a/websockets/conversation.go
+++ b/websockets/conversation.go
@@ -138,6 +138,10 @@ func (c *Conversation) Run() {
 				c.deleteClient(message.sender)
 				continue
 			}
+			if !ok {
+				log.Printf("Patch %s could not be applied", update.Patch)
+				continue
+			}
 
 			broadcastMessage := message.content
 			if update.Version != originalVersion {


### PR DESCRIPTION
Doesn't do anything with the cursor delta value for now.

The `processUpdate` method handles trying to apply the patch in an update, checking whether applying the patch succeeded, and adjusting the version number of the update. If it returns `true`, then the `Run` method will broadcast out the update to every other client.

Also had to fix the error handling logic in the `broadcast` case of the `Run` method to properly shut down a client when an unexpected error occurs.