### PR TITLE
Add SQL setup code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /tmp ./...
 FROM scratch
 WORKDIR /
 COPY --from=builder /tmp/* ./
+COPY dbSchema.sql ./
 EXPOSE 80
 ENTRYPOINT ["/app"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PATCHES_DB_HOST?=localhost
 PATCHES_DB_PORT?=5432
 PATCHES_DB_USERNAME?=postgres
 PATCHES_DB_PASSWORD?=patches
-PATCHES_DB_DATABASE?=patches
 HELP_FUNC = \
     %help; \
     while(<>) { \
@@ -48,7 +47,6 @@ run: build 			## build and run the app binaries
 		export PATCHES_DB_PORT="${PATCHES_DB_PORT}" && \
 		export PATCHES_DB_USERNAME="${PATCHES_DB_USERNAME}" && \
 		export PATCHES_DB_PASSWORD="${PATCHES_DB_PASSWORD}" && \
-		export PATCHES_DB_DATABASE="${PATCHES_DB_DATABASE}" && \
 		./tmp/app
 
 docker: tmp 		## build the docker image

--- a/app/server.go
+++ b/app/server.go
@@ -16,12 +16,12 @@ import (
 
 func main() {
 	connectionString := fmt.Sprintf(
-		"host=%s port=%s user=%s "+"password=%s dbname=%s sslmode=disable",
+		"host=%s port=%s user=%s password=%s sslmode=disable",
 		os.Getenv("PATCHES_DB_HOST"),
 		os.Getenv("PATCHES_DB_PORT"),
 		os.Getenv("PATCHES_DB_USERNAME"),
 		os.Getenv("PATCHES_DB_PASSWORD"),
-		os.Getenv("PATCHES_DB_DATABASE"))
+	)
 	db, err := models.DBConnect(connectionString)
 	if err != nil {
 		log.Fatal(err)

--- a/dbSchema.sql
+++ b/dbSchema.sql
@@ -1,0 +1,11 @@
+CREATE TYPE patchtype AS ENUM ('edit');
+
+CREATE TABLE IF NOT EXISTS patches (
+  time TIMESTAMPTZ NOT NULL,
+  patch TEXT NOT NULL,
+  convo_id INTEGER,
+  user_id INTEGER,
+  type PATCHTYPE
+);
+
+SELECT create_hypertable('patches', 'time');

--- a/models/db.go
+++ b/models/db.go
@@ -2,11 +2,13 @@ package models
 
 import (
 	"database/sql"
-	"log"
+	"io/ioutil"
+	"strings"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
+// Datastore defines the CRUD operations of patches in the database
 type Datastore interface {
 	CreatePatch(patch *Patch) error
 	GetPatches(filter *Filter) ([]Patch, error)
@@ -18,19 +20,65 @@ type DB struct {
 	*sql.DB
 }
 
-// Connect to database
+// DBConnect initializes a new DB
 func DBConnect(connectionString string) (*DB, error) {
 	db, err := sql.Open("postgres", connectionString)
 	if err != nil {
-		log.Fatal(err)
 		return nil, err
 	}
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec("CREATE DATABASE patches"); err != nil {
+		if err, ok := err.(*pq.Error); ok && err.Code != pq.ErrorCode("42P04") {
+			return nil, err
+		}
+	}
+	db.Close()
 
-	err = db.Ping()
+	db, err = sql.Open("postgres", connectionString+" dbname=patches")
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+	if err := setupTable(db); err != nil {
 		return nil, err
 	}
 
 	return &DB{db}, nil
+}
+
+// setupTable creates the necessary "patches" table if it doesn't already exist.
+func setupTable(db *sql.DB) error {
+	var tmp string
+
+	// Check if the "patches" table exists by querying for the table. If it does
+	// exist, just return.
+	queryTable := "SELECT table_name FROM information_schema.tables WHERE table_name='patches'"
+	err := db.QueryRow(queryTable).Scan(&tmp)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	} else if err != sql.ErrNoRows {
+		return nil
+	}
+
+	sqlScript, err := ioutil.ReadFile("dbSchema.sql")
+	if err != nil {
+		return err
+	}
+
+	statements := strings.Split(string(sqlScript), ";")
+	if len(statements) > 0 {
+		statements = statements[:len(statements)-1]
+	}
+
+	for _, statement := range statements {
+		_, err = db.Exec(statement)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/models/patch.go
+++ b/models/patch.go
@@ -10,26 +10,26 @@ import (
 type Patch struct {
 	Timestamp time.Time `json:"timestamp"`
 	Patch     string    `json:"patch"`
-	ConvoID   string    `json:"convo_id"`
-	UserID    string    `json:"user_id"`
+	ConvoID   int64     `json:"convo_id"`
+	UserID    int64     `json:"user_id"`
 	Type      string    `json:"type"`
 }
 
 type Filter struct {
-	Conversation string    `schema:"convo_id"`
-	User         []string  `schema:"user_id"`
+	Conversation int64     `schema:"convo_id"`
+	User         []int64   `schema:"user_id"`
 	Type         []string  `schema:"type"`
 	EndTime      time.Time `schema:"end_time"`
 	StartTime    time.Time `schema:"start_time"`
 }
 
-// Get patch rows from database using filters
+// GetPatches gets patch rows from the database using filters
 func (db *DB) GetPatches(filter *Filter) ([]Patch, error) {
 
 	// Create filter string
 	filterString := new(strings.Builder)
-	if filter.Conversation != "" {
-		fmt.Fprintf(filterString, "convo_id = %s", filter.Conversation)
+	if filter.Conversation != 0 {
+		fmt.Fprintf(filterString, "convo_id = %d", filter.Conversation)
 	} else {
 		log.Print("Error with conversation id")
 		return nil, nil
@@ -40,9 +40,9 @@ func (db *DB) GetPatches(filter *Filter) ([]Patch, error) {
 
 		for i, userID := range filter.User {
 			if i == 0 {
-				fmt.Fprintf(filterString, "user_id = %s", userID)
+				fmt.Fprintf(filterString, "user_id = %d", userID)
 			} else {
-				fmt.Fprintf(filterString, " OR user_id = %s", userID)
+				fmt.Fprintf(filterString, " OR user_id = %d", userID)
 			}
 		}
 
@@ -54,9 +54,9 @@ func (db *DB) GetPatches(filter *Filter) ([]Patch, error) {
 
 		for i, patchType := range filter.Type {
 			if i == 0 {
-				fmt.Fprintf(filterString, "type = %s", patchType)
+				fmt.Fprintf(filterString, "type = '%s'", patchType)
 			} else {
-				fmt.Fprintf(filterString, " OR type = %s", patchType)
+				fmt.Fprintf(filterString, " OR type = '%s'", patchType)
 			}
 		}
 
@@ -76,12 +76,12 @@ func (db *DB) GetPatches(filter *Filter) ([]Patch, error) {
 	queryString := new(strings.Builder)
 	fmt.Fprintf(queryString, "SELECT * FROM patches WHERE %s", filterString)
 	rows, err := db.Query(queryString.String())
-	defer rows.Close()
 	if err != nil {
 		log.Print("Error getting rows")
 		log.Print(err)
 		return nil, err
 	}
+	defer rows.Close()
 
 	p := Patch{}
 	patches := make([]Patch, 0)
@@ -98,7 +98,7 @@ func (db *DB) GetPatches(filter *Filter) ([]Patch, error) {
 	return patches, err
 }
 
-// Add new patch to the database
+// CreatePatch adds a new patch to the database
 func (db *DB) CreatePatch(patch *Patch) error {
 
 	// Insert patch into database
@@ -112,7 +112,7 @@ func (db *DB) CreatePatch(patch *Patch) error {
 	return nil
 }
 
-// Delete patches from the database by conversation
+// DeletePatches deletes patches from the database by conversation
 func (db *DB) DeletePatches(convo_id int64) (int64, error) {
 
 	// Delete patches from db


### PR DESCRIPTION
Resolves #27 

This is a bit different than how `karen` and `ether` do it. PostreSQL doesn't have a `USE` SQL command, so first we need to create the database, then re-open the DB with the newly created database. Then, for the table creation stuff, there's a couple commands that don't have `IF NOT EXISTS` support, so instead the code just runs a query on the tables and if there is no `patches` table, then it'll run the SQL commands in the `dbSchema.sql` file.

Also, there were a couple of bugs in the code for querying the database, so I fixed those.