### PR TITLE
Fix WebSocket timeout

### DIFF
--- a/websockets/client.go
+++ b/websockets/client.go
@@ -3,8 +3,21 @@ package websockets
 import (
 	"log"
 	"patches/protocol"
+	"time"
 
+	"github.com/gorilla/websocket"
 	gorillaws "github.com/gorilla/websocket"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
 )
 
 // Client manages a WebSocket connection with a client.
@@ -45,6 +58,11 @@ func (c *Client) read() {
 		c.broker.unregister(c)
 	}()
 
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
 	for {
 		_, data, err := c.conn.ReadMessage()
 		if err != nil {
@@ -61,18 +79,36 @@ func (c *Client) read() {
 // write sends messages to the WebSocket connection whenever new messages are
 // sent into the Client's channel.
 func (c *Client) write() {
+	ticker := time.NewTicker(pingPeriod)
 	defer func() {
-		c.conn.WriteMessage(
-			gorillaws.CloseMessage,
-			gorillaws.FormatCloseMessage(gorillaws.CloseGoingAway, "Going away"),
-		)
+		ticker.Stop()
+		c.conn.Close()
 	}()
 
-	for message := range c.send {
-		err := c.conn.WriteMessage(gorillaws.TextMessage, message)
-		if err != nil {
-			log.Print("Failed to write message to WebSocket: ", err)
-			return
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				c.conn.WriteMessage(
+					gorillaws.CloseMessage,
+					gorillaws.FormatCloseMessage(gorillaws.CloseGoingAway, "Going away"),
+				)
+				return
+			}
+
+			err := c.conn.WriteMessage(gorillaws.TextMessage, message)
+			if err != nil {
+				log.Print("Failed to write message to WebSocket: ", err)
+				return
+			}
+
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				log.Print("Failed to write ping message to WebSocket: ", err)
+				return
+			}
 		}
 	}
 }

--- a/websockets/client.go
+++ b/websockets/client.go
@@ -5,7 +5,6 @@ import (
 	"patches/protocol"
 	"time"
 
-	"github.com/gorilla/websocket"
 	gorillaws "github.com/gorilla/websocket"
 )
 
@@ -105,7 +104,7 @@ func (c *Client) write() {
 
 		case <-ticker.C:
 			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			if err := c.conn.WriteMessage(gorillaws.PingMessage, nil); err != nil {
 				log.Print("Failed to write ping message to WebSocket: ", err)
 				return
 			}

--- a/websockets/conversation.go
+++ b/websockets/conversation.go
@@ -7,6 +7,7 @@ import (
 	"patches/kafka"
 	"patches/models"
 	"patches/protocol"
+	"time"
 
 	gorillaws "github.com/gorilla/websocket"
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -294,6 +295,7 @@ func (c *Conversation) registerClient(client *Client) error {
 	if err != nil {
 		return err
 	}
+	client.conn.SetWriteDeadline(time.Now().Add(writeWait))
 	err = client.conn.WriteMessage(gorillaws.TextMessage, initMessage)
 	if err != nil {
 		return err


### PR DESCRIPTION
Resolves #31 
Resolves #30 

Now whenever anything is written to/read from a client WebSocket connection (besides closing messages), a finite timeout is sent. Previously there was an infinite wait. Also added ping-pong logic, so if nothing is getting written to the WebSocket for 54 seconds, then a ping message will be sent and a pong response will be expected.

Also added more useful WebSocket closing messages in the connection setup phase.